### PR TITLE
Fix UB in argv preparing 

### DIFF
--- a/macos11ghcwa.c
+++ b/macos11ghcwa.c
@@ -89,8 +89,8 @@ static char** fix_ghc_argv (const char* topdir, char* const argv[])
     const int argc = num_elems (argv);
     char** new_argv = malloc ((argc + 2) * sizeof (char* const));
     new_argv[0] = argv[0];
-    memcpy (new_argv + 2, argv + 1, (argc + 1) * sizeof (char*));
     new_argv[1] = append ("-B", topdir);
+    memcpy (new_argv + 2, argv + 1, argc * sizeof (char*));
     return new_argv;
 }
 
@@ -121,9 +121,9 @@ static char** fix_runghc_argv (const char* folder, char* const argv[])
     const int argc = num_elems (argv);
     char** new_argv = malloc ((argc + 3) * sizeof (char* const));
     new_argv[0] = argv[0];
-    memcpy (new_argv + 3, argv + 1, (argc + 1) * sizeof (char*));
     new_argv[1] = "-f";
     new_argv[2] = append (folder, "bin/ghc");
+    memcpy (new_argv + 3, argv + 1, argc * sizeof (char*));
     return new_argv;
 }
 


### PR DESCRIPTION
Hi!

You [allocate](https://github.com/yairchu/macos11-haskell-workaround/blob/main/macos11ghcwa.c#L122) an array of length `argc + 3`. But you are accessing `argc + 4` elements (3 elements directly and `argc + 1` via `memcpy`).

After fixing it I have no problem with random crashes like [this](https://github.com/yairchu/macos11-haskell-workaround/issues/1#issuecomment-743697701).

But more testing is required